### PR TITLE
Implement expansion within meta predicate scope

### DIFF
--- a/prolog/function_expansion.pl
+++ b/prolog/function_expansion.pl
@@ -37,23 +37,118 @@
 :- dynamic user:function_expansion/3.
 :- multifile user:function_expansion/3.
 
-expand_arglist([], [], []).
-expand_arglist([H0|T0], [H|T], [Guard|Guards]) :-  % leaf
-    nonvar(H0),
-    user:function_expansion(H0, H, Guard),
-    expand_arglist(T0, T, Guards),
+%!    expand(+Goal, -Expanded) is semidet
+%
+%     Performs top level function expansion on =Goal= resulting in
+%     =Expanded=.
+expand(Goal, Expanded) :-
+    expand(0, Goal, Expanded, _).
+
+%!    expand(+MSpec, +Term, -Expanded, -Guards) is semidet
+%
+%     =MSpec= is a meta argument specifier (see meta_predicate/1).
+%
+%     TODO: meta argument specifier '^' is not supported. Not sure
+%     what the best way to support it is, since it is not a predicate
+%     itself and we only want to treat it as such when it is not the
+%     enclosing context of the bagof/3, setof/3, etc.
+%
+%     TODO: support '//' meta argument
+%
+expand(MSpec, Term, Expanded, Guards) :-
+    % This does the expansion of Term
+    expand_aux(Term,
+               Expanded0   /* expanded Term */,
+               Guards0,    /* list of guards for Term */
+               WasExpanded /* did any expansion take place in Term? */
+              ),
+
+    %% This uses MSpec to determine whether to merge the expansion and
+    %% guards here, or to send the guards up to the parent of Term. 
+    (WasExpanded == true -> 
+         (% if term is not callable, pass guards to parent
+             memberchk(MSpec, ['+', '*', '?', '-', ':']) ->  
+             Expanded-Guards = Expanded0-Guards0
+         ; % if term is a callable expecting MSpec additional args,
+           % merge expanded term and guards, and send empty list of guards to parent
+           (integer(MSpec), MSpec >= 0) -> % 
+           term_guards_goal(MSpec, Expanded0, Guards0, Expanded),
+           Guards = [] 
+         ;
+         print_message(warning, function_expansion(incomplete(Term, unsupported_meta_argument_specifier(MSpec))))
+         )
+    ; % WasExpanded == false ->
+      Expanded-Guards = Expanded0-Guards0
+    ).
+
+%!    expand_aux(+Term, -Expanded, -Guards, -WasExpanded) is semidet
+%
+%     Expands =Term= into an expanded term =Expanded=, a list of gaurd
+%     goals =Guards=. =WasExpanded= is true if any actual expansion
+%     occured.
+%
+expand_aux(Term, Term, [], WasExpanded) :- 
+    var(Term),
+    !,
+    WasExpanded = false.
+expand_aux(Term0, Term1, [Guard], WasExpanded) :-
+    user:function_expansion(Term0, Term1, Guard),    
+    !,
+    WasExpanded = true.
+expand_aux(Term, Expanded, Guards, WasExpanded) :-
+    Term =.. [_],
+    !,
+    Expanded = Term,
+    Guards = [],
+    WasExpanded = false,
     !.
-expand_arglist([H0|T0], [H|T], Guards) :-          % subtree
-    nonvar(H0),
-    H0 =.. [Functor|Args0],
-    expand_arglist(Args0, Args, NestedGuards),
-    H =.. [Functor|Args],
-    expand_arglist(T0, T, TailGuards),
-    append(NestedGuards, TailGuards, Guards),
+expand_aux(Term, Expanded, Guards, WasExpanded) :-
+    Term =.. [F|Args0],
+    length(Args0, A), 
+    pred_meta_arg_specs(F/A, MSpecs),
+    maplist(expand, MSpecs, Args0, Args, GuardLists),
+    append(GuardLists, Guards),
+    Expanded =.. [F|Args],
+    (Term \== Expanded ->
+         WasExpanded = true;
+     WasExpanded = false
+    ),
     !.
-expand_arglist([H0|T0], [H0|T], Guards) :-
-    var(H0),
-    expand_arglist(T0, T, Guards).
+expand_aux(Term, Term, [], false).
+    
+
+term_guards_goal(_, Term, [], Goal) :-
+    !,
+    Term = Goal.
+term_guards_goal(A, Term, Guards, Goal) :-
+    xfy_list(',', GuardTerm, Guards),
+    (A =:= 0 ->
+         Goal = (GuardTerm, Term)
+    ; % otherwise, eta expand
+      length(Vs, A),
+      Goal1 =.. [call, Term|Vs],
+      Goal = Vs >> (GuardTerm, Goal1)
+    ).
+    
+
+
+pred_meta_arg_specs(F/A, MetaArgSpecs) :-
+    (known_meta_arg_specs(F/A, MetaArgSpecs) ->
+        true
+    ;
+     default_meta_arg_specs(F/A, MetaArgSpecs)
+    ).
+
+known_meta_arg_specs(F/A, MetaArgSpecs) :-
+    functor(H, F, A), 
+    predicate_property(H, meta_predicate(MSpec)),
+    MSpec =.. [_|MetaArgSpecs].
+
+default_meta_arg_specs(_/A, Types) :-
+    length(Types, A),
+    maplist(=('?'), Types).
+
+    
 
 %%	xfy_list(?Op:atom, ?Term, ?List) is det.
 %
@@ -68,7 +163,10 @@ xfy_list(Op, Term, [Left|List]) :-
     Term =.. [Op, Left, Right],
     xfy_list(Op, Right, List),
     !.
-xfy_list(_, Term, [Term]).
+xfy_list(_, Term, [Term]).    
+
+    
+
 
 %%	control(+Term) is semidet.
 %
@@ -79,15 +177,17 @@ control((_->_)).
 control((_*->_)).
 control(\+(_)).
 
+
 user:goal_expansion(T0, T) :-
     \+ control(T0),  % goal_expansion/2 already descends into these
-    T0 =.. [Functor|Args],
-    function_expansion:expand_arglist(Args, NewArgs, Preconditions),
-    T1 =.. [Functor|NewArgs],
+    
+    %% NB: this is needed because expand/2 calls predicate_property/2
+    %% which then tries to load the module in which a predicate is
+    %% defined, which in tern calls goal_expansion/2, leading to an
+    %% infinite loop ... not sure this completely solves the issue
+    \+ prolog_load_context(term, :- module(_, _)),
+    
+    expand(T0, T).
 
-    % remove guards that are always true
-    exclude(==(true), Preconditions, NoTrues),
-    (   xfy_list(',', Guard, NoTrues)
-    ->  T = (Guard, T1)
-    ;   T = T1   % empty guard clause
-    ).
+
+

--- a/t/synopsis.pl
+++ b/t/synopsis.pl
@@ -1,13 +1,23 @@
 % vim: filetype=prolog
 :- use_module(library(function_expansion)).
+
+%% :- prolog_load_context(directory, Dir),
+   %% asserta(user:file_search_path(here, Dir)).
+
+%% :- use_module(here('../prolog/function_expansion.pl')).
+
 user:function_expansion(incr(N), X, X is N+1).
 user:function_expansion(pi_atom, Atom, true) :-
     Pi is pi,
     atom_number(Atom, Pi).
 
+user:function_expansion(Term, Z, succ(Y, Z)) :-
+    Term = succ(Y, W),
+    W == '~'.
+
 :- use_module(library(tap)).
 
-% not exactly what's in the synopsis, but close
+%% not exactly what's in the synopsis, but close
 'incr(N)' :-
     format(atom(A), 'After 2 comes ~p', [incr(2)]),
     A = 'After 2 comes 3'.
@@ -16,3 +26,14 @@ user:function_expansion(pi_atom, Atom, true) :-
 'pi function producing an atom' :-
     % test only the prefix to avoid system-dependent float problems
     atom_concat('3.14159', _, pi_atom).
+
+'incr(N) in meta_predicate scope' :-
+    findall(X, (Y = 1, X = incr(Y)), Xs),
+    Xs == [2].
+
+call(succ(succ(1, ~)), 3).
+
+
+
+
+


### PR DESCRIPTION
The code is rewritten for the most part, because we can't just move
guards to the top level of the expansion. So instead we need to
accumulate guards and then either send them up to the parent term or
prepend them to the current term depending on the meta_predicate
specification of the calling goal.

To deal with meta arguments that require N>0 number of additional
arguments we construct a lambda term (as in library(yall)) to prepend
the resulting guard and then pipe the outside arguments to the expanded
term. I.e. if T expands to T' with guard G in the first argument of
call/3 we have an expansion of the form

```
call(T, X, Y) ==> call([A, B] >> (H, call(T', A, B)), X, Y)
```

I have more tests, but they all involve tilde expansion so I put them in library(func). Maybe, they should go here though?
